### PR TITLE
Pre-flight checks should not generate 'changed' status

### DIFF
--- a/tasks/precheck.yml
+++ b/tasks/precheck.yml
@@ -2,6 +2,7 @@
 
 - name: Requirements check | Checking sse4_2 support
   command: grep -q sse4_2 /proc/cpuinfo
+  changed_when: False
 
 - name: Requirements check | Not supported distribution && release
   fail:
@@ -13,6 +14,4 @@
   register: clickhouse_rt_isinstalled
   ignore_errors: yes
   when: ansible_pkg_mgr == 'apt' and clickhouse_setup == 'package'
-
-
-
+  changed_when: False


### PR DESCRIPTION
Currently the role generates two 'changed' on each run regardless of actual changes on server.
Both of them are coming from 'preflight' checks. Those checks should fail if condition is not met,
but they shouldn't generate 'changed' status on success.

This pull request fixes this by adding 'changed_when: False' to both those tasks.