### PR TITLE
Add default value for clickhouse_dicts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -77,4 +77,5 @@ clickhouse_config:
   max_session_timeout: 3600
   default_session_timeout: 60
 
+clickhouse_dicts: []
 


### PR DESCRIPTION
This allow users to omit `clickhouse_dicts` in configuration
if they have no dictionaries to configure.