### PR TITLE
Create/delete database no longer generate 'changed' when nessessary

### DIFF
--- a/tasks/config_db.yml
+++ b/tasks/config_db.yml
@@ -1,11 +1,18 @@
+---
+- name: Gather list of existing databases
+  command: "clickhouse-client -h localhost -q 'show databases'"
+  changed_when: False
+  register: existing_databases
+  tags: [config_db]
+
 - name: Config | Delete database config
   command: "clickhouse-client -h localhost -q 'DROP DATABASE IF EXISTS `{{ item.name }}`'"
   with_items: "{{ clickhouse_dbs }}"
-  when: item.state is defined and item.state == 'absent'
+  when: item.state is defined and item.state == 'absent' and item.name in existing_databases.stdout.lines_lines
   tags: [config_db]
 
 - name: Config | Create database config
   command: "clickhouse-client -h localhost -q 'CREATE DATABASE IF NOT EXISTS `{{ item.name }}`'"
   with_items: "{{ clickhouse_dbs }}"
-  when: item.state is undefined or item.state == 'present'
+  when: (item.state is undefined or item.state == 'present') and item.name not in existing_databases.stdout_lines
   tags: [config_db]


### PR DESCRIPTION
Database manipulation is split into two parts:
- Gather list of existing databases (always no changes)
- Process list of databases to create/delete an element.

If given database is already is in the desired state, no changes are made.

This eliminates false 'changed' reports from ansible for the case
when clickhouse_dbs is not empty and databases are exist already.