### PR TITLE
Use default values for users quota and profile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,6 +89,7 @@ script:
   - clickhouse-client -q 'select 1' -d testu1
   - clickhouse-client -q 'select 1' -d testu2 -u testuser2 --password testplpassword
   - clickhouse-client -q 'select 1' -d testu3
+  - clickhouse-client -q 'select 1' -d testu3 -u testuser_for_defaults --password testplpassword
   #Full remove check
   - ansible-playbook tests/test.yml -i tests/inventory -e "clickhouse_remove=yes clickhouse_remove_full=yes" -v
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -78,4 +78,5 @@ clickhouse_config:
   default_session_timeout: 60
 
 clickhouse_dicts: []
-
+clickhouse_default_user_profile: default
+clickhouse_default_user_quota: default

--- a/templates/users.j2
+++ b/templates/users.j2
@@ -43,8 +43,8 @@
         <ip>{{ net }}</ip>
         {% endfor %}
         </networks>
-        <profile>{{ user.profile }}</profile>
-        <quota>{{ user.quota }}</quota>
+        <profile>{{ user.profile|default(clickhouse_default_user_profile) }}</profile>
+        <quota>{{ user.quota|default(clickhouse_default_user_quota) }}</quota>
         {% if user.dbs is defined %}
          <allow_databases>
         {% for db in user.dbs %}

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -26,6 +26,11 @@
           quota: "default",
           dbs: {testu1,testu2,testu3} ,
           comment: "classic user with multi dbs and multi-custom network allow password"}
+      - { name: "testuser_for_defaults",
+          password: "testplpassword",
+          networks: { 192.168.0.0/24, 10.0.0.0/8 },
+          dbs: {testu1,testu2,testu3} ,
+          comment: "User with default profile and password"}
     clickhouse_dbs_custom:
       - { name: testu1 }
       - { name: testu2 }


### PR DESCRIPTION
Now `clickhouse_default_user_profile` and `clickhouse_default_user_quota`
are used if any user in `clickhouse_users_custom` have no profile or quota
field specified.

Those values are set to 'default' which corresponds to default
values for Clickhouse: 'default' quota, 'default' profile.
Example of a shorter user definition:

 clickhouse_users_custom:
  - name: "someuser",
    password: "somepassword",
    networks:
     - 192.168.0.0/24
     - 10.0.0.0/8
    dbs:
     somedatabase:

Partially-closes: #13