### PR TITLE
Sometime server not yet ready for requests, sleep 1 fixes that issue

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,6 +27,9 @@
   when: clickhouse_rt_isinstalled.rc == 0 and clickhouse_remove|bool == False
   tags: [config,config_sys]
 
+- name: Wait DBMS ready
+  command: sleep 1
+
 - include: config_db.yml
   when: clickhouse_rt_isinstalled.rc == 0 and clickhouse_remove|bool == False
   tags: [config,config_db]


### PR DESCRIPTION
OS
```
# lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 16.04.4 LTS
Release:	16.04
Codename:	xenial
```

Ansible output
```
RUNNING HANDLER [AlexeySetevoi.clickhouse : restart-ch] **************************************************************************************************************************
changed: [stripstat2]

TASK [AlexeySetevoi.clickhouse : Gather list of existing databases] **************************************************************************************************************
fatal: [stripstat2]: FAILED! => {"changed": false, "cmd": ["clickhouse-client", "-h", "localhost", "-q", "show databases"], "delta": "0:00:00.014458", "end": "2018-10-03 23:52:34.602409", "msg": "non-zero return code", "rc": 210, "start": "2018-10-03 23:52:34.587951", "stderr": "Code: 210. DB::NetException: Connection refused: (localhost:9000, ::1)", "stderr_lines": ["Code: 210. DB::NetException: Connection refused: (localhost:9000, ::1)"], "stdout": "", "stdout_lines": []}

PLAY RECAP ***********************************************************************************************************************************************************************
xxxstat                 : ok=13   changed=2    unreachable=0    failed=1
```