### PR TITLE
Update Debian_stretch.yml

### DIFF
--- a/vars/Debian_stretch.yml
+++ b/vars/Debian_stretch.yml
@@ -1,6 +1,6 @@
 clickhouse_supported: yes
 clickhouse_repo: "deb http://repo.yandex.ru/clickhouse/deb/stable/ main/"
-clickhouse_repo_keyserver: keyserver.ubuntu.com
+clickhouse_repo_keyserver: hkp://keyserver.ubuntu.com:80
 clickhouse_repo_key: E0C56BD4
 clickhouse_package:
   - clickhouse-client


### PR DESCRIPTION
The problem has on the debian 9 with apt-key

https://unix.stackexchange.com/questions/399027/gpg-keyserver-receive-failed-server-indicated-a-failure