### PR TITLE
Don't need to restart clickhouse after users.xml modification

### DIFF
--- a/tasks/config_sys.yml
+++ b/tasks/config_sys.yml
@@ -27,7 +27,6 @@
     dest: "{{ clickhouse_path_configdir }}/users.xml"
     owner: clickhouse
     group: clickhouse
-  notify: restart-ch
   become: true
 
 - name: Config | Create conf folder


### PR DESCRIPTION
Don't need to restart clickhouse after users.xml modification, clickhouse reload this file on-fly:
https://stackoverflow.com/questions/45062749/how-to-make-clickhouse-take-new-users-xml-file