### PR TITLE
fix: compatibility remote_servers.j2 with python3

### DIFF
--- a/templates/remote_servers.j2
+++ b/templates/remote_servers.j2
@@ -2,7 +2,7 @@
 <!-- {{ ansible_managed }} -->
 <yandex>
   <remote_servers>
-{% for shard_name, replicas in clickhouse_shards.iteritems() %}
+{% for shard_name, replicas in clickhouse_shards.items() | list %}
     <{{ shard_name }}>
       <shard>
         <internal_replication>true</internal_replication>


### PR DESCRIPTION
Current form support only Python 2, proposed form support both Python 2 and Python 3

Documentation about supporting Python versions [here](https://docs.ansible.com/ansible/latest/user_guide/playbooks_python_version.html#dict-iteritems)