### PR TITLE
Fix create empty auto dictionary.xml

### DIFF
--- a/tasks/config_dict.yml
+++ b/tasks/config_dict.yml
@@ -3,3 +3,4 @@
    src: dicts.j2
    dest: "{{ clickhouse_path_configdir }}/auto_dictionary.xml"
   become: true
+  when: clickhouse_dicts is defined and ( clickhouse_dicts|length>0 )

--- a/templates/remote_servers.j2
+++ b/templates/remote_servers.j2
@@ -2,7 +2,7 @@
 <!-- {{ ansible_managed }} -->
 <yandex>
   <remote_servers>
-{% for shard_name, replicas in clickhouse_shards.iteritems() %}
+{% for shard_name, replicas in clickhouse_shards.items() | list %}
     <{{ shard_name }}>
       <shard>
         <internal_replication>true</internal_replication>


### PR DESCRIPTION
If variable `clickhouse_dicts` is empty - generated config `auto_dictionary.xml` is wrong and ClickHouse stop working.

In this PR added check for create `auto_dictionary.xml` only if `clickhouse_dicts` not empty list

@AlexeySetevoi please review this PR