### PR TITLE
Allow configuring dictionary lazy loading

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -76,6 +76,8 @@ clickhouse_logger:
   size: 1000M
   count: 10
 
+clickhouse_config_dictionaries_lazy_load: true
+
 clickhouse_config:
   max_connections: 2048
   keep_alive_timeout: 3
@@ -83,6 +85,7 @@ clickhouse_config:
   uncompressed_cache_size: 8589934592
   mark_cache_size: 5368709120
   builtin_dictionaries_reload_interval: 3600
+  dictionaries_lazy_load: "{{ clickhouse_config_dictionaries_lazy_load }}"
   max_session_timeout: 3600
   default_session_timeout: 60
 

--- a/templates/config.j2
+++ b/templates/config.j2
@@ -174,6 +174,9 @@
     <!-- Reloading interval for embedded dictionaries, in seconds. Default: 3600. -->
     <builtin_dictionaries_reload_interval>{{ clickhouse_config.builtin_dictionaries_reload_interval }}</builtin_dictionaries_reload_interval>
 
+    <!-- If true, dictionaries are created lazily on first use. Otherwise they are initialised on server startup. Default: true -->
+    <!-- See also: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server_configuration_parameters-dictionaries_lazy_load -->
+    <dictionaries_lazy_load>{{ clickhouse_config.dictionaries_lazy_load }}</dictionaries_lazy_load>
 
     <!-- Maximum session timeout, in seconds. Default: 3600. -->
     <max_session_timeout>{{ clickhouse_config.max_session_timeout }}</max_session_timeout>


### PR DESCRIPTION
See docs here - https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server_configuration_parameters-dictionaries_lazy_load