### PR TITLE
Added "port" option with to "Check clickhouse server is ready" task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,7 +24,7 @@
   tags: [config,config_sys]
 
 - name: Check clickhouse server is ready
-  command: "clickhouse-client -h 127.0.0.1 -q 'select 1'"
+  command: "clickhouse-client -h 127.0.0.1 --port {{ clickhouse_tcp_port }} -q 'select 1'"
   changed_when: False
   retries: "{{ clickhouse_ready_retries }}"
   delay: "{{ clickhouse_ready_delay }}"


### PR DESCRIPTION
Added "port" option with to "Check clickhouse server is ready" task to prevent task failing on configuration with non-standard tcp port