### PR TITLE
Fix dicts.j2 template

### DIFF
--- a/templates/dicts.j2
+++ b/templates/dicts.j2
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 {{ ansible_managed | comment('xml') }}
-<dictionaries>
+<yandex>
 {% for dict in clickhouse_dicts %}
  <dictionary>
    <name>{{ clickhouse_dicts[dict].name }}</name>
@@ -42,4 +42,4 @@
    </structure>
  </dictionary>
 {% endfor %}
-</dictionaries>
+</yandex>


### PR DESCRIPTION
Hello!

I've tried to deploy the role with a list of dictionaries in `clickhouse_dicts` variable and got this error:

> 2021.08.17 14:32:32.316330 [ 15692 ] {} <Error> ExternalDictionariesLoader: Failed to load config file '/etc/clickhouse-server/auto_dictionary.xml': Poco::Exception. Code: 1000, e.code() = 0, e.displayText() = Exception: Failed to merge config with '/etc/clickhouse-server/conf.d/clickhouse_remote_servers.xml': Exception: Root element doesn't have the corresponding root element as the config file. It must be <dictionaries>, Stack trace (when copying this message, always include the lines below):

According to [documentation](https://clickhouse.tech/docs/en/sql-reference/dictionaries/external-dictionaries/external-dicts/) it must use tags `<yandex></yandex>` instead of `<dictionaries>`.

So, could you merge this PR, please?