### PR TITLE
Fixed bug which produce error: "The task includes an option with an u…

### DIFF
--- a/tasks/install/dnf.yml
+++ b/tasks/install/dnf.yml
@@ -33,7 +33,7 @@
   dnf:
     name: "{{ clickhouse_package | map('regex_replace', '$', '-' + clickhouse_version) | list }}"
     state: present
-    disable_gpg_check: "{{ true if clickhouse_version == 19.4.0 else omit }}" 
+    disable_gpg_check: "{{ true if clickhouse_version == '19.4.0' else omit }}" 
   become: true
   tags: [install]
   when: clickhouse_version != 'latest'

--- a/tasks/install/yum.yml
+++ b/tasks/install/yum.yml
@@ -33,7 +33,7 @@
   yum:
     name: "{{ clickhouse_package | map('regex_replace', '$', '-' + clickhouse_version) | list }}"
     state: present
-    disable_gpg_check: "{{ true if clickhouse_version == 19.4.0 else omit }}" 
+    disable_gpg_check: "{{ true if clickhouse_version == '19.4.0' else omit }}" 
   become: true
   tags: [install]
   when: clickhouse_version != 'latest'


### PR DESCRIPTION
Fixed bug which produce error: "The task includes an option with an undefined variable. The error was: float object has no element 0" in text vs float comparison.

AUsing ansible version 2.10.7 with python version 3.9.2