### PR TITLE
Remove CentOS 7 from CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
     strategy:
       matrix:
         scenario:
-          - centos_7
           - debian_bullseye
           - debian_buster
           - debian_jessie


### PR DESCRIPTION
Remove the no longer supported CentOS 7 distribution.