### PR TITLE
Remove Debian Jessie from CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ jobs:
           - centos_7
           - debian_bullseye
           - debian_buster
-          - debian_jessie
           - debian_stretch
           - ubuntu_bionic
           - ubuntu_focal


### PR DESCRIPTION
Debian Jessie is no longer officially supported.