### PR TITLE
Remove unsupported CentOS 8 from CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
       matrix:
         scenario:
           - centos_7
-          - centos_8
           - debian_bullseye
           - debian_buster
           - debian_jessie


### PR DESCRIPTION
CentOS 8 has reached end-of-life.