### PR TITLE
Update to new Apt repo configuration

### DIFF
--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -1,9 +1,9 @@
 ---
 clickhouse_supported: true
-clickhouse_repo: "deb https://repo.clickhouse.tech/deb/stable/ main/"
+clickhouse_repo: "deb https://packages.clickhouse.com/deb stable main"
 clickhouse_repo_old: >-
   deb
   http://repo.yandex.ru/clickhouse/{{ansible_distribution_release}}
   stable main
 clickhouse_repo_keyserver: keyserver.ubuntu.com
-clickhouse_repo_key: E0C56BD4
+clickhouse_repo_key: 8919F6BD2B48D754


### PR DESCRIPTION
The recommended apt repo has been moved to packages.clickhouse.com
according to https://clickhouse.com/docs/en/getting-started/install/#install-from-deb-packages