### PR TITLE
Update configs and README.md with Yandex -> ClickHouse, Inc changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ F: Flag for remove clickhouse from host(disabled by default)
 clickhouse_remove: no
 ```
 
-F: You can manage [Kafka configuration](https://clickhouse.yandex/docs/en/operations/table_engines/kafka/#configuration)
+F: You can manage [Kafka configuration](https://clickhouse.com/docs/en/engines/table-engines/integrations/kafka/#configuration)
 ```yaml
 # global configuration
 clickhouse_kafka_config:
@@ -214,7 +214,7 @@ clickhouse_ldap_user_directories:
       prefix: "clickhouse_
 ```
 
-F: You can manage Merge Tree config. For the list of available parameters, see [MergeTreeSettings.h](https://github.com/yandex/ClickHouse/blob/master/dbms/src/Storages/MergeTree/MergeTreeSettings.h).
+F: You can manage Merge Tree config. For the list of available parameters, see [MergeTree tables settings](https://clickhouse.com/docs/en/operations/settings/merge-tree-settings/).
 ```yaml
 clickhouse_merge_tree_config:
   max_suspicious_broken_parts: 5
@@ -326,7 +326,7 @@ BSD
 Author Information
 ------------------
 
-[ClickHouse](https://clickhouse.yandex/docs/en/index.html) by [Yandex LLC](https://yandex.ru/company/).
+[ClickHouse](https://clickhouse.com/docs/en/index.html) by [ClickHouse, Inc.](https://clickhouse.com/company/).
 
 Role by [AlexeySetevoi](https://github.com/AlexeySetevoi).
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,7 @@ galaxy_info:
   role_name: clickhouse
   namespace: alexeysetevoi
   author: Alexey V. Bobrov
-  description: Role for installation and managing Yandex.ClickHouse
+  description: Role for installation and managing ClickHouse
 
   license: MIT
   

--- a/tasks/install/apt.yml
+++ b/tasks/install/apt.yml
@@ -1,6 +1,6 @@
 ---
 #Main installation actions
-#https://clickhouse.yandex/docs/en/getting_started/index.html#installation
+#https://clickhouse.com/docs/en/getting-started/#installation
 
 - name: Install by APT | Apt-key add repo key
   apt_key:

--- a/tasks/install/dnf.yml
+++ b/tasks/install/dnf.yml
@@ -1,6 +1,6 @@
 ---
 #Main installation actions
-#https://clickhouse.yandex/docs/en/getting_started/index.html#installation
+#https://clickhouse.com/docs/en/getting-started/#installation
 
 - name: Install by YUM | Ensure clickhouse repo GPG key imported
   rpm_key:

--- a/tasks/install/yum.yml
+++ b/tasks/install/yum.yml
@@ -1,6 +1,6 @@
 ---
 #Main installation actions
-#https://clickhouse.yandex/docs/en/getting_started/index.html#installation
+#https://clickhouse.com/docs/en/getting-started/#installation
 
 - name: Install by YUM | Ensure clickhouse repo GPG key imported
   rpm_key:

--- a/tasks/remove/apt.yml
+++ b/tasks/remove/apt.yml
@@ -1,6 +1,6 @@
 ---
 #Main installation actions
-#https://clickhouse.yandex/docs/en/getting_started/index.html#installation
+#https://clickhouse.com/docs/en/getting-started/#installation
 
 - name: Uninstall by APT | Package uninstallation
   apt:

--- a/tasks/remove/dnf.yml
+++ b/tasks/remove/dnf.yml
@@ -1,6 +1,6 @@
 ---
 #Main installation actions
-#https://clickhouse.yandex/docs/en/getting_started/index.html#installation
+#https://clickhouse.com/docs/en/getting-started/#installation
 
 - name: Uninstall by YUM | Ensure clickhouse package uninstalled
   dnf:

--- a/tasks/remove/yum.yml
+++ b/tasks/remove/yum.yml
@@ -1,6 +1,6 @@
 ---
 #Main installation actions
-#https://clickhouse.yandex/docs/en/getting_started/index.html#installation
+#https://clickhouse.com/docs/en/getting-started/#installation
 
 - name: Uninstall by YUM | Ensure clickhouse package uninstalled
   yum:

--- a/templates/config.j2
+++ b/templates/config.j2
@@ -1,7 +1,7 @@
 #jinja2: trim_blocks: True, lstrip_blocks: True
 <?xml version="1.0"?>
 {{ ansible_managed | comment('xml') }} 
-<yandex>
+<clickhouse>
     <logger>
         <!-- Possible levels: https://github.com/pocoproject/poco/blob/develop/Foundation/include/Poco/Logger.h#L105 -->
         <level>{{ clickhouse_logger.level }}</level>
@@ -61,7 +61,7 @@
          This setting could be used to switch replication to another network interface.
       -->
     <!--
-    <interserver_http_host>example.yandex.ru</interserver_http_host>
+    <interserver_http_host>example.clickhouse.com</interserver_http_host>
     -->
 {% if clickhouse_interserver_http_host is defined %}
     <interserver_http_host>{{ clickhouse_interserver_http_host }}</interserver_http_host>
@@ -146,27 +146,26 @@
     <mlock_executable>{{ clickhouse_mlock_status }}</mlock_executable>
 
     <!-- Configuration of clusters that could be used in Distributed tables.
-         https://clickhouse.yandex/docs/en/table_engines/distributed/
+         https://clickhouse.com/docs/en/engines/table-engines/special/distributed/
       -->
     <remote_servers incl="clickhouse_remote_servers" />
 
 
     <!-- If element has 'incl' attribute, then for it's value will be used corresponding substitution from another file.
          By default, path to file with substitutions is /etc/metrika.xml. It could be changed in config in 'include_from' element.
-         Values for substitutions are specified in /yandex/name_of_substitution elements in that file.
+         Values for substitutions are specified in /clickhouse/name_of_substitution elements in that file.
       -->
 
     <!-- ZooKeeper is used to store metadata about replicas, when using Replicated tables.
          Optional. If you don't use replicated tables, you could omit that.
 
-         See https://clickhouse.yandex/docs/en/table_engines/replication/
+         See https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/replication/
       -->
     <zookeeper incl="zookeeper-servers" optional="true" />
 
     <!-- Substitutions for parameters of replicated tables.
           Optional. If you don't use replicated tables, you could omit that.
-
-         See https://clickhouse.yandex/docs/en/table_engines/replication/#creating-replicated-tables
+         See https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/replication/#creating-replicated-tables
       -->
     <macros incl="macros" optional="true" />
 
@@ -175,7 +174,7 @@
     <builtin_dictionaries_reload_interval>{{ clickhouse_config.builtin_dictionaries_reload_interval }}</builtin_dictionaries_reload_interval>
 
     <!-- If true, dictionaries are created lazily on first use. Otherwise they are initialised on server startup. Default: true -->
-    <!-- See also: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server_configuration_parameters-dictionaries_lazy_load -->
+    <!-- See also: https://clickhouse.com/docs/en/operations/server-configuration-parameters/settings/#server_configuration_parameters-dictionaries_lazy_load -->
     <dictionaries_lazy_load>{{ clickhouse_config.dictionaries_lazy_load }}</dictionaries_lazy_load>
 
     <!-- Maximum session timeout, in seconds. Default: 3600. -->
@@ -256,7 +255,7 @@
         <database>system</database>
         <table>query_log</table>
         <!--
-            PARTITION BY expr https://clickhouse.yandex/docs/en/table_engines/custom_partitioning_key/
+            PARTITION BY expr https://clickhouse.com/docs/en/table_engines/mergetree-family/custom_partitioning_key/
             Example:
                 event_date
                 toMonday(event_date)
@@ -291,7 +290,7 @@
 
 
     <!-- Parameters for embedded dictionaries, used in Yandex.Metrica.
-         See https://clickhouse.yandex/docs/en/dicts/internal_dicts/
+         See https://clickhouse.com/docs/en/dicts/internal_dicts/
     -->
 
     <!-- Path to file with region hierarchy. -->
@@ -302,7 +301,7 @@
 
 
     <!-- Configuration of external dictionaries. See:
-         https://clickhouse.yandex/docs/en/dicts/external_dicts/
+         https://clickhouse.com/docs/en/sql-reference/dictionaries/external-dictionaries/external-dicts
     -->
     <dictionaries_config>*_dictionary.xml</dictionaries_config>
 
@@ -512,4 +511,4 @@
   </s3>
 {% endif %}
 
-</yandex>
+</clickhouse>

--- a/templates/dicts.j2
+++ b/templates/dicts.j2
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 {{ ansible_managed | comment('xml') }}
-<yandex>
+<clickhouse>
 {% for dict in clickhouse_dicts %}
  <dictionary>
    <name>{{ clickhouse_dicts[dict].name }}</name>
@@ -42,4 +42,4 @@
    </structure>
  </dictionary>
 {% endfor %}
-</yandex>
+</clickhouse>

--- a/templates/macros.j2
+++ b/templates/macros.j2
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 {{ ansible_managed | comment('xml') }}
-<yandex>
+<clickhouse>
   <macros>
 {% for key, value in clickhouse_macros.items() %}
     <{{ key }}>{{ value }}</{{ key }}>
 {% endfor %}
   </macros>
-</yandex>
+</clickhouse>

--- a/templates/remote_servers.j2
+++ b/templates/remote_servers.j2
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 {{ ansible_managed | comment('xml') }}
-<yandex>
+<clickhouse>
   <remote_servers>
 {% for clusters_name, shards_name in clickhouse_clusters.items() | list %}
     <{{ clusters_name }}>
@@ -18,4 +18,4 @@
     </{{ clusters_name }}>
 {% endfor %}
   </remote_servers>
-</yandex>
+</clickhouse>

--- a/templates/users.j2
+++ b/templates/users.j2
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 {{ ansible_managed | comment('xml') }} 
-<yandex>
+<clickhouse>
    <profiles>
     <!-- Profiles of settings. -->
     <!-- Default profiles. -->
@@ -121,4 +121,4 @@
     </{{ quota.name }}>
     {% endfor %}
     </quotas>
-</yandex>
+</clickhouse>

--- a/templates/zookeeper-servers.j2
+++ b/templates/zookeeper-servers.j2
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 {{ ansible_managed | comment('xml') }} 
-<yandex>
+<clickhouse>
   <zookeeper>
 {% for server in clickhouse_zookeeper_nodes %}
     <node index="{{loop.index}}">
@@ -10,4 +10,4 @@
     </node>
 {% endfor %}
   </zookeeper>
-</yandex>
+</clickhouse>


### PR DESCRIPTION
With the incorporation of ClickHouse into it's own company independent of Yandex some changes have been made.

* Documentation pages has been moved
* Config is wrapped with `<clickhouse></clickhouse>` instead of `<yandex></yandex>`

This will bring the config and documentation back into sync with the official information.