### PR TITLE
Allow deployment of cluster with security hardening configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,12 +300,78 @@ Including an example of how to use your role (for instance, with variables passe
     roles:
       - ansible-clickhouse
 ```
+
 To generate macros: in file host_vars\db_host_1.yml
 ```yaml
 clickhouse_macros:
   layer: 01
   shard: "your_shard_name"
   replica: "db_host_1"
+```
+
+Security harden the cluster. You can configure the cluster with extra settings
+which enables
+- HTTPS port
+- TLS Encrypted TCP port
+- HTTPS for data replication
+- Credentials for data replication
+- Secret validation for distributed queries
+- ZooKeeper ACL
+```yaml
+- hosts: clickhouse_cluster
+  become: true
+  roles:
+    - ansible-clickhouse
+  vars:
+    # HTTPS instead of normal HTTP
+    clickhouse_https_port: 8443
+    # TLS encryption for the native TCP protocol (needs `clickhouse-client --secure`)
+    clickhouse_tcp_secure_port: 9440
+    # TLS encryption between nodes in cluster
+    clickhouse_interserver_https: 9010
+    # Credentials used to authenticate nodes during data replication
+    clickhouse_interserver_http_credentials:
+      user: "internal"
+      password: "supersecretstring"
+    # Secret used to validate nodes in cluster for distributed queries
+    clickhouse_distributed_secret: "supersecretstring2"
+    # Password protect zookeeper paths used by ClickHouse
+    clickhouse_zookeeper_identity:
+      user: "zoo_user"
+      password: "secretzoostring"
+    # OpenSSL settings
+    clickhouse_ssl_server:
+      certificate_file: "/etc/clickhouse-server/server.crt"
+      private_key_file: "/etc/clickhouse-server/server.key"
+      dh_params_file: "/etc/clickhouse-server/dhparam.pem"
+      verification_mode: "none"
+      load_default_ca_file: "true"
+      cache_sessions: "true"
+      disable_protocols: "sslv2,sslv3"
+      prefer_server_ciphers: "true"
+    clickhouse_clusters:
+      your_cluster_name:
+        shard_1:
+          - host: "db_host_1"
+            port: 9440
+            secure: true
+          - host: "db_host_2"
+            port: 9440
+            secure: true
+        shard_2:
+          - host: "db_host_3"
+            port: 9440
+            secure: true
+          - host: "db_host_4"
+            port: 9440
+            secure: true
+    clickhouse_zookeeper_nodes:
+      - host: "zoo_host_1"
+        port: 2181
+      - host: "zoo_host_2"
+        port: 2181
+      - host: "zoo_host_3"
+        port: 2181
 ```
 
 F: You can call separately stages(from playbook, external role etc.):

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -65,6 +65,10 @@ clickhouse_interserver_http: 9009
 
 # clickhouse_distributed_secret: "secretstring"
 
+# clickhouse_zookeeper_identity:
+#   user: "zoo-user"
+#   password: "secretstring"
+
 clickhouse_networks_default:
   - "::1"
   - "127.0.0.1"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,11 +34,10 @@ clickhouse_listen_host_custom: []
 clickhouse_listen_host: "{{ clickhouse_listen_host_default + clickhouse_listen_host_custom }}"
 
 clickhouse_http_port: 8123
-
 clickhouse_tcp_port: 9000
 
-clickhouse_https_port: 8443
-clickhouse_tcp_secure_port: 9440
+# clickhouse_https_port: 8443
+# clickhouse_tcp_secure_port: 9440
 
 clickhouse_interserver_http: 9009
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,6 +57,13 @@ clickhouse_ssl_client:
   invalid_certificate_handler_name: "RejectCertificateHandler"
 
 clickhouse_interserver_http: 9009
+# clickhouse_interserver_https: 9010
+
+# clickhouse_interserver_http_credentials:
+#   user: "internal"
+#   password: "secretstring"
+
+# clickhouse_distributed_secret: "secretstring"
 
 clickhouse_networks_default:
   - "::1"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,6 +39,23 @@ clickhouse_tcp_port: 9000
 # clickhouse_https_port: 8443
 # clickhouse_tcp_secure_port: 9440
 
+clickhouse_ssl_server:
+  certificate_file: "/etc/clickhouse-server/server.crt"
+  private_key_file: "/etc/clickhouse-server/server.key"
+  dh_params_file: "/etc/clickhouse-server/dhparam.pem"
+  verification_mode: "none"
+  load_default_ca_file: "true"
+  cache_sessions: "true"
+  disable_protocols: "sslv2,sslv3"
+  prefer_server_ciphers: "true"
+
+clickhouse_ssl_client:
+  load_default_ca_file: "true"
+  cache_sessions: "true"
+  disable_protocols: "sslv2,sslv3"
+  prefer_server_ciphers: "true"
+  invalid_certificate_handler_name: "RejectCertificateHandler"
+
 clickhouse_interserver_http: 9009
 
 clickhouse_networks_default:

--- a/tasks/configure/db.yml
+++ b/tasks/configure/db.yml
@@ -1,13 +1,16 @@
 ---
+- name: Set ClickHose Connection String
+  set_fact: clickhouse_connection_string="clickhouse-client -h 127.0.0.1 --port {{ clickhouse_tcp_secure_port | default(clickhouse_tcp_port) }}{{' --secure' if clickhouse_tcp_secure_port is defined else '' }}"
+
 - name: Gather list of existing databases
-  command: "clickhouse-client -h 127.0.0.1 --port {{ clickhouse_tcp_port }} -q 'show databases'"
+  command: "{{ clickhouse_connection_string }} -q 'show databases'"
   changed_when: False
   register: existing_databases
   tags: [config_db]
 
 - name: Config | Delete database config
   command: |
-    clickhouse-client -h 127.0.0.1 --port {{ clickhouse_tcp_port }}
+    {{ clickhouse_connection_string }}
     -q 'DROP DATABASE IF EXISTS `{{ item.name }}`
     {% if item.cluster is defined %}ON CLUSTER `{{ item.cluster }}`{% endif %}'
   with_items: "{{ clickhouse_dbs }}"
@@ -16,7 +19,7 @@
 
 - name: Config | Create database config
   command: |
-    clickhouse-client -h 127.0.0.1 --port {{ clickhouse_tcp_port }}
+    {{ clickhouse_connection_string }}
     -q 'CREATE DATABASE IF NOT EXISTS `{{ item.name }}`
     {% if item.cluster is defined %}ON CLUSTER `{{ item.cluster }}`{% endif %}
     {% if item.engine is defined %}ENGINE = {{ item.engine }}{% endif %}'

--- a/tasks/configure/sys.yml
+++ b/tasks/configure/sys.yml
@@ -51,8 +51,6 @@
     mode: "ug=rw,o-rwx"
   become: true
 
-
-
 - name: Config | Generate remote_servers config
   template:
     src: remote_servers.j2
@@ -84,4 +82,12 @@
     mode: "u=rw,og=r"
   notify: restart-ch
   become: true
-  when: clickhouse_zookeeper_nodes is defined 
+  when: clickhouse_zookeeper_nodes is defined
+
+- name: Config | Fix interserver_http_port and intersever_https_port collision
+  lineinfile:
+    path: "{{ clickhouse_path_configdir }}/config.xml"
+    search_string: '<interserver_http_port>'
+    state: absent
+  become: true
+  when: clickhouse_interserver_https is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,7 +44,7 @@
 
 - name: "Wait for Clickhouse Server to Become Ready"
   wait_for:
-    port: "{{ clickhouse_tcp_port }}"
+    port: "{{ clickhouse_tcp_secure_port | default(clickhouse_tcp_port) }}"
     delay: "{{ clickhouse_ready_delay }}"
   when: not clickhouse_remove|bool
 

--- a/templates/config.j2
+++ b/templates/config.j2
@@ -57,7 +57,19 @@
     -->
 
     <!-- Port for communication between replicas. Used for data exchange. -->
+{% if clickhouse_interserver_https is defined %}
+    <interserver_https_port>{{ clickhouse_interserver_https }}</interserver_https_port>
+{% else %}
     <interserver_http_port>{{ clickhouse_interserver_http }}</interserver_http_port>
+{% endif %}
+
+{% if clickhouse_interserver_http_credentials is defined %}
+<interserver_http_credentials>
+    <user>{{ clickhouse_interserver_http_credentials.user }}</user>
+    <password>{{ clickhouse_interserver_http_credentials.password }}</password>
+</interserver_http_credentials>
+{% endif %}
+
 
     <!-- Hostname that is used by other replicas to request this server.
          If not specified, than it is determined analoguous to 'hostname -f' command.

--- a/templates/config.j2
+++ b/templates/config.j2
@@ -27,26 +27,26 @@
     <openSSL>
         <server> <!-- Used for https server AND secure tcp port -->
             <!-- openssl req -subj "/CN=localhost" -new -newkey rsa:2048 -days 365 -nodes -x509 -keyout /etc/clickhouse-server/server.key -out /etc/clickhouse-server/server.crt -->
-            <certificateFile>/etc/clickhouse-server/server.crt</certificateFile>
-            <privateKeyFile>/etc/clickhouse-server/server.key</privateKeyFile>
+            <certificateFile>{{ clickhouse_ssl_server.certificate_file }}</certificateFile>
+            <privateKeyFile>{{ clickhouse_ssl_server.private_key_file }}</privateKeyFile>
             <!-- openssl dhparam -out /etc/clickhouse-server/dhparam.pem 4096 -->
-            <dhParamsFile>/etc/clickhouse-server/dhparam.pem</dhParamsFile>
-            <verificationMode>none</verificationMode>
-            <loadDefaultCAFile>true</loadDefaultCAFile>
-            <cacheSessions>true</cacheSessions>
-            <disableProtocols>sslv2,sslv3</disableProtocols>
-            <preferServerCiphers>true</preferServerCiphers>
+            <dhParamsFile>{{ clickhouse_ssl_server.dh_params_file }}</dhParamsFile>
+            <verificationMode>{{ clickhouse_ssl_server.verification_mode }}</verificationMode>
+            <loadDefaultCAFile>{{ clickhouse_ssl_server.load_default_ca_file }}</loadDefaultCAFile>
+            <cacheSessions>{{ clickhouse_ssl_server.cache_sessions }}</cacheSessions>
+            <disableProtocols>{{ clickhouse_ssl_server.disable_protocols }}</disableProtocols>
+            <preferServerCiphers>{{ clickhouse_ssl_server.prefer_server_ciphers }}</preferServerCiphers>
         </server>
 
         <client> <!-- Used for connecting to https dictionary source -->
-            <loadDefaultCAFile>true</loadDefaultCAFile>
-            <cacheSessions>true</cacheSessions>
-            <disableProtocols>sslv2,sslv3</disableProtocols>
-            <preferServerCiphers>true</preferServerCiphers>
+            <loadDefaultCAFile>{{ clickhouse_ssl_client.load_default_ca_file }}</loadDefaultCAFile>
+            <cacheSessions>{{ clickhouse_ssl_client.cache_sessions }}</cacheSessions>
+            <disableProtocols>{{ clickhouse_ssl_client.disable_protocols }}</disableProtocols>
+            <preferServerCiphers>{{ clickhouse_ssl_client.prefer_server_ciphers }}</preferServerCiphers>
             <!-- Use for self-signed: <verificationMode>none</verificationMode> -->
             <invalidCertificateHandler>
                 <!-- Use for self-signed: <name>AcceptCertificateHandler</name> -->
-                <name>RejectCertificateHandler</name>
+                <name>{{ clickhouse_ssl_client.invalid_certificate_handler_name }}</name>
             </invalidCertificateHandler>
         </client>
     </openSSL>

--- a/templates/config.j2
+++ b/templates/config.j2
@@ -11,14 +11,17 @@
         <count>{{ clickhouse_logger.count }}</count>
     </logger>
 
-    <http_port>{{ clickhouse_http_port }}</http_port>
-    <tcp_port>{{ clickhouse_tcp_port }}</tcp_port>
-
-    <!-- For HTTPS and SSL over native protocol. -->
-    <!--
+{% if clickhouse_https_port is defined %}
     <https_port>{{ clickhouse_https_port }}</https_port>
+{% else %}
+    <http_port>{{ clickhouse_http_port }}</http_port>
+{% endif %}
+
+{% if clickhouse_tcp_secure_port is defined %}
     <tcp_port_secure>{{ clickhouse_tcp_secure_port }}</tcp_port_secure>
-    -->
+{% else %}
+    <tcp_port>{{ clickhouse_tcp_port }}</tcp_port>
+{% endif %}
 
     <!-- Used with https_port and tcp_port_secure. Full ssl options list: https://github.com/ClickHouse-Extras/poco/blob/master/NetSSL_OpenSSL/include/Poco/Net/SSLManager.h#L71 -->
     <openSSL>

--- a/templates/remote_servers.j2
+++ b/templates/remote_servers.j2
@@ -4,14 +4,20 @@
   <remote_servers>
 {% for clusters_name, shards_name in clickhouse_clusters.items() | list %}
     <{{ clusters_name }}>
+{% if clickhouse_distributed_secret is defined %}
+        <secret>{{ clickhouse_distributed_secret }}</secret>
+{% endif %}
 {% for shard_name, replicas  in shards_name.items() %}
         <shard>
-        <internal_replication>true</internal_replication>
+          <internal_replication>true</internal_replication>
 {% for replica in replicas %}
-        <replica>
-          <host>{{ replica['host'] }}</host>
-          <port>{{ replica['port'] | default(9000) }}</port>
-        </replica>
+          <replica>
+            <host>{{ replica['host'] }}</host>
+            <port>{{ replica['port'] | default(9000) }}</port>
+{% if 'secure' in replica %}
+            <secure>1</secure>
+{% endif %}
+          </replica>
 {% endfor %}
       </shard>
 {% endfor %}      

--- a/templates/zookeeper-servers.j2
+++ b/templates/zookeeper-servers.j2
@@ -2,6 +2,9 @@
 {{ ansible_managed | comment('xml') }} 
 <yandex>
   <zookeeper>
+{% if clickhouse_zookeeper_identity is defined %}
+    <identity>{{ clickhouse_zookeeper_identity.user }}:{{clickhouse_zookeeper_identity.password }}</identity>
+{% endif %}
 {% for server in clickhouse_zookeeper_nodes %}
     <node index="{{loop.index}}">
 {% for key, value in server.items() %}


### PR DESCRIPTION
Provides the ability to set up ClickHouse according to normal security hardening recommendations.

It provides
- Working HTTPS port (commented out before)
- TLS Encrypted TCP port
- HTTPS for data replication
- Credentials for data replication
- Secret validation for distributed queries
- ZooKeeper ACL

It is important to note though that this is a bit opinionated in a couple of ways. First, it will not configure normal HTTP or TCP (in `config.d/config.xml`) if HTTPS and secure TCP are configured. However, I do not go in and remove the default http_port and tcp_port configuration in the global `config.xml`  which means that the default HTTP and TCP ports will still be exposed due to how the configuration is applied (on top of the default configuration). However, for internal replication, we need to go in and remove the default string from the global config simply because this will conflict with the internal_https configuration.

In my own deployment, I go even further and remove the normal HTTP and TCP configuration from the global `config.xml`. Perhaps that would be nice to include as well? It depends on what you would like and what the users would expect.