### PR TITLE
Exclude clickhouse packages from apt upgrades

### DIFF
--- a/tasks/install/apt.yml
+++ b/tasks/install/apt.yml
@@ -41,3 +41,13 @@
   become: true
   when: clickhouse_version == 'latest'
   tags: [install]
+
+- name: Hold specified version during APT upgrade | Package installation
+  become: true
+  copy:
+    dest: "/etc/apt/preferences.d/fixed-{{ item }}"
+    content: |
+      Package: {{ item }}
+      Pin: release a=now
+      Pin-Priority: 1001
+  loop: "{{ clickhouse_package }}"


### PR DESCRIPTION
Utilize apt preferences to exclude clickhouse packages from apt upgrades. 

Before users could accidentally upgrade their clickhouse versions by running apt update and apt upgrade on Debian / Ubuntu distros.

These preference files simply state that the current version should be kept.

Tested on Ubuntu 20.04 LTS