### PR TITLE
Add missing time unit for clickhouse_query_log_ttl

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ clickhouse_listen_host_custom:
 
 F: you can manage ttl query_log:
 ```yaml
-clickhouse_query_log_ttl: 'event_date + INTERVAL 7  DELETE'
+clickhouse_query_log_ttl: 'event_date + INTERVAL 7 DAY DELETE'
 ```
 
 F: Or you can specify ips directly e.g. to listen on all ipv4 and ipv6 addresses:


### PR DESCRIPTION
Without the time unit specified, ClickHouse throws an exception and refuses to start:

```
2022.04.30 17:17:51.953133 [ 2266573 ] {} <Error> Application: Caught exception while loading metadata: Code: 62. DB::Exception: Syntax error (Storage to create table for query_log): failed at position 86 ('DELETE'): DELETE ORDER BY (event_date, event_time). Expected one of: token, DoubleColon, MOD, DIV, NOT, BETWEEN, LIKE, ILIKE, NOT LIKE, NOT ILIKE, IN, NOT IN, GLOBAL IN, GLOBAL NOT IN, IS, AND, OR, QuestionMark, alias, AS, NANOSECOND, SQL_TSI_NANOSECOND, NS, MICROSECOND, SQL_TSI_MICROSECOND, MCS, MILLISECOND, SQL_TSI_MILLISECOND, MS, SECOND, SQL_TSI_SECOND, SS, S, MINUTE, SQL_TSI_MINUTE, MI, N, HOUR, SQL_TSI_HOUR, HH, DAY, SQL_TSI_DAY, DD, D, WEEK, SQL_TSI_WEEK, WK, WW, MONTH, SQL_TSI_MONTH, MM, M, QUARTER, SQL_TSI_QUARTER, QQ, Q, YEAR, SQL_TSI_YEAR, YYYY, YY, end of query. (SYNTAX_ERROR), Stack trace (when copying this message, always include the lines below):

0. DB::Exception::Exception(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, bool) @ 0xb6fbffa in /usr/bin/clickhouse
1. DB::parseQueryAndMovePosition(DB::IParser&, char const*&, char const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool, unsigned long, unsigned long) @ 0x1758e59f in /usr/bin/clickhouse
2. DB::SystemLogs::SystemLogs(std::__1::shared_ptr<DB::Context const>, Poco::Util::AbstractConfiguration const&) @ 0x162f4e3c in /usr/bin/clickhouse
3. DB::Context::initializeSystemLogs() @ 0x15cf6bcf in /usr/bin/clickhouse
4. DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&) @ 0xb78673a in /usr/bin/clickhouse
5. Poco::Util::Application::run() @ 0x1b402846 in /usr/bin/clickhouse
6. DB::Server::run() @ 0xb775294 in /usr/bin/clickhouse
7. mainEntryClickHouseServer(int, char**) @ 0xb7728e7 in /usr/bin/clickhouse
8. main @ 0xb6f59b3 in /usr/bin/clickhouse
9. __libc_start_main @ 0x7faf692630b3 in ?
10. _start @ 0xb4daf2e in /usr/bin/clickhouse
 (version 22.4.4.7 (official build))
2022.04.30 17:17:52.956254 [ 2266573 ] {} <Error> Application: DB::Exception: Syntax error (Storage to create table for query_log): failed at position 86 ('DELETE'): DELETE ORDER BY (event_date, event_time). Expected one of: token, DoubleColon, MOD, DIV, NOT, BETWEEN, LIKE, ILIKE, NOT LIKE, NOT ILIKE, IN, NOT IN, GLOBAL IN, GLOBAL NOT IN, IS, AND, OR, QuestionMark, alias, AS, NANOSECOND, SQL_TSI_NANOSECOND, NS, MICROSECOND, SQL_TSI_MICROSECOND, MCS, MILLISECOND, SQL_TSI_MILLISECOND, MS, SECOND, SQL_TSI_SECOND, SS, S, MINUTE, SQL_TSI_MINUTE, MI, N, HOUR, SQL_TSI_HOUR, HH, DAY, SQL_TSI_DAY, DD, D, WEEK, SQL_TSI_WEEK, WK, WW, MONTH, SQL_TSI_MONTH, MM, M, QUARTER, SQL_TSI_QUARTER, QQ, Q, YEAR, SQL_TSI_YEAR, YYYY, YY, end of query
```