### PR TITLE
fix baseurl for yum repo

### DIFF
--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -1,3 +1,3 @@
 ---
 clickhouse_supported: yes
-clickhouse_repo: "https://packages.clickhouse.com/rpm/clickhouse.repo"
+clickhouse_repo: "https://packages.clickhouse.com/rpm/stable/"


### PR DESCRIPTION
Installation is impossible.
https://packages.clickhouse.com/rpm/clickhouse.repo - is a link for a repo file. It's not where rpm's stored.
Correct link - https://packages.clickhouse.com/rpm/stable/