### PR TITLE
GPG key import and disable verification for RedHat. 

### DIFF
--- a/tasks/install/dnf.yml
+++ b/tasks/install/dnf.yml
@@ -25,6 +25,7 @@
   dnf:
     name: "{{ clickhouse_package }} "
     state: "{{ clickhouse_version }}"
+    disable_gpg_check: true
   become: true
   tags: [install]
   when: clickhouse_version == 'latest'
@@ -33,7 +34,7 @@
   dnf:
     name: "{{ clickhouse_package | map('regex_replace', '$', '-' + clickhouse_version) | list }}"
     state: present
-    disable_gpg_check: "{{ true if clickhouse_version == '19.4.0' else omit }}" 
+    disable_gpg_check: true
   become: true
   tags: [install]
   when: clickhouse_version != 'latest'

--- a/tasks/install/yum.yml
+++ b/tasks/install/yum.yml
@@ -17,6 +17,7 @@
   yum:
     name: "{{ clickhouse_package }} "
     state: "{{ clickhouse_version }}"
+    disable_gpg_check: true
   become: true
   tags: [install]
   when: clickhouse_version == 'latest'
@@ -25,7 +26,7 @@
   yum:
     name: "{{ clickhouse_package | map('regex_replace', '$', '-' + clickhouse_version) | list }}"
     state: present
-    disable_gpg_check: "{{ true if clickhouse_version == '19.4.0' else omit }}" 
+    disable_gpg_check: true
   become: true
   tags: [install]
   when: clickhouse_version != 'latest'

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -1,3 +1,4 @@
 ---
 clickhouse_supported: yes
 clickhouse_repo: "https://packages.clickhouse.com/rpm/stable/"
+clickhouse_repo_key: "https://packages.clickhouse.com/rpm/stable/repodata/repomd.xml.key"


### PR DESCRIPTION
Added clickhouse_repo_key variable for redhat:
```
TASK [alexeysetevoi.clickhouse : Install by YUM | Ensure clickhouse repo GPG key imported] ************************************************
Friday 09 September 2022  21:22:47 +0300 (0:00:00.042)       0:00:02.634 ****** 
fatal: [***]: FAILED! => {"msg": "The task includes an option with an undefined variable.
The error was: 'clickhouse_repo_key' is undefined\n\nThe error appears to be in 'roles/galaxy/alexeysetevoi.clickhouse/tasks/install/dnf.yml': line 5, column 3, but may\n
be elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:
\n\n\n- name: Install by YUM | Ensure clickhouse repo GPG key imported\n  ^ here\n"}
```
Disabled GPG check for yum install:
```
TASK [alexeysetevoi.clickhouse : Install by YUM | Ensure clickhouse package installed (latest)] ************************************
Friday 09 September 2022  21:15:47 +0300 (0:00:00.444)       0:00:03.176 ****** 
fatal: [***]: FAILED! => {"changed": false, "msg": "Failed to validate GPG signature for clickhouse-common-static-22.8.4.7-1.x86_64"}
```
OS:
```
Red Hat Enterprise Linux release 8.5 (Ootpa)
```