### PR TITLE
Add user/password support to the remote_servers template

### DIFF
--- a/templates/remote_servers.j2
+++ b/templates/remote_servers.j2
@@ -14,6 +14,12 @@
           <replica>
             <host>{{ replica['host'] }}</host>
             <port>{{ replica['port'] | default(9000) }}</port>
+{% if replica['user'] is defined %}
+            <user>{{ replica['user'] }}</user>
+{% endif %}
+{% if replica['password'] is defined %}
+            <password>{{ replica['password'] }}</password>
+{% endif %}
 {% if 'secure' in replica %}
             <secure>1</secure>
 {% endif %}


### PR DESCRIPTION
Add support for `user` and `password` parameters for `clickhouse_remote_servers.xml`, necessary if you're using something other than the default user